### PR TITLE
feat: remove checkout from jest-coverage

### DIFF
--- a/jest-coverage/action.yml
+++ b/jest-coverage/action.yml
@@ -10,7 +10,6 @@ runs:
   using: composite
 
   steps:
-    - uses: actions/checkout@v3
     - uses: actions/download-artifact@v3
       with:
         name: coverage-artifacts


### PR DESCRIPTION
Means we don't nuke the repo beforehand in case we need artefacts