### PR TITLE
Tag images by run id

### DIFF
--- a/deploy-to-cloudformation/action.yml
+++ b/deploy-to-cloudformation/action.yml
@@ -73,6 +73,6 @@ runs:
         parameters-file: configs/${{ inputs.ldt-environment }}.json
         changeset-postfix: -${{ github.sha }}
         parameter-overrides: |
-          ECRImage: ${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ inputs.ldt-environment }}-${{ github.sha }}
+          ECRImage: ${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ inputs.ldt-environment }}-${{ github.sha }}-${{ github.run_attempt }}
           CommitHash: ${{ github.sha }}
           ${{ inputs.parameter-overrides }}

--- a/deploy-to-cloudformation/action.yml
+++ b/deploy-to-cloudformation/action.yml
@@ -61,6 +61,10 @@ runs:
         role-duration-seconds: 900
         role-skip-session-tagging: true
 
+    - name: Validate Image
+      shell: bash
+      run: docker manifest inspect ${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ inputs.ldt-environment }}-${{ github.sha }}-${{ github.run_attempt }} > /dev/null ; echo $?
+
     - name: Deploy to cloudformation
       id: deploy-to-cloudformation
       uses: stampedeapp/aws-cloudformation-github-deploy@master

--- a/deploy-to-ecr/action.yml
+++ b/deploy-to-ecr/action.yml
@@ -64,7 +64,7 @@ runs:
         context: .
         builder: ${{ steps.buildx.outputs.name }}
         push: true
-        tags: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image-name }}:${{ inputs.ldt-environment }}-${{ github.sha }}
+        tags: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image-name }}:${{ inputs.ldt-environment }}-${{ github.sha }}-${{ github.run_attempt }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
         build-args: |


### PR DESCRIPTION
This prevents rebuilds of images with different environment variables or config. 

1. Updates image tags to include `run_id` 
2. Validates that an image exists in ECR before creating a changeset