### PR TITLE
Workflows/feat/test setup command

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -12,6 +12,12 @@ on:
         description: Run e2e tests before deploying
         required: false
         default: 'false'
+      test-setup-command:
+        type: string
+        description: Command to run to setup the test environment
+        required: false
+        default: ''
+
 
 env:
   NODE_AUTH_TOKEN: ${{ secrets.NPM_READONLY_TOKEN }}
@@ -29,6 +35,8 @@ jobs:
     uses: stampedeapp/actions/.github/workflows/static.yml@main
     needs: install
     secrets: inherit
+    with:
+      test-setup-command: ${{ inputs.test-setup-command }}
 
   build-staging:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,11 @@ on:
         description: SHA of the commit to use for deployment
         required: false
         default: ${{ github.sha }}
+      test-setup-command:
+        type: string
+        description: Command to run to setup the test environment
+        required: false
+        default: ''
 
 env:
   NODE_AUTH_TOKEN: ${{ secrets.NPM_READONLY_TOKEN }}
@@ -38,6 +43,8 @@ jobs:
     uses: stampedeapp/actions/.github/workflows/static.yml@main
     needs: install
     secrets: inherit
+    with:
+      test-setup-command: ${{ inputs.test-setup-command }}
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,6 +2,12 @@ name: Static
 
 on:
   workflow_call:
+    inputs:
+      test-setup-command:
+        type: string
+        description: Command to run to setup the test environment
+        required: false
+        default: ''
 
 env:
   NODE_AUTH_TOKEN: ${{ secrets.NPM_READONLY_TOKEN }}
@@ -23,5 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: stampedeapp/actions/setup@main
+      - run: ${{ test-setup-command }}
+        if: ${{ inputs.test-setup-command != '' }}
       - uses: stampedeapp/actions/jest@main
       - uses: stampedeapp/actions/jest-coverage@main

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: stampedeapp/actions/setup@main
-      - run: ${{ test-setup-command }}
+      - run: ${{ inputs.test-setup-command }}
         if: ${{ inputs.test-setup-command != '' }}
       - uses: stampedeapp/actions/jest@main
       - uses: stampedeapp/actions/jest-coverage@main


### PR DESCRIPTION
Add test-setup-command for test setup. Segmentation service currently uses it. I'd love to user proper service containers but this was always gonna be the cost of reusable workflows.