### PR TITLE
Cloudformation/feat/cli auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: stampedeapp/actions/check-code-freeze@main
         with:
           github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
-      - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
+      - uses: stampedeapp/actions/deploy-to-cloudformation-cli@wip
         with:
           stack-name: ${{ inputs.stack-name }}
           ldt-environment: ${{ inputs.ldt-environment }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: stampedeapp/actions/check-code-freeze@main
         with:
           github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
-      - uses: stampedeapp/actions/deploy-to-cloudformation-cli@wip
+      - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:
           stack-name: ${{ inputs.stack-name }}
           ldt-environment: ${{ inputs.ldt-environment }}

--- a/deploy-to-cloudformation-cli/action.yml
+++ b/deploy-to-cloudformation-cli/action.yml
@@ -54,13 +54,17 @@ runs:
             --output text
         )" >> $GITHUB_OUTPUT
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-region: ${{ inputs.region }}
-        role-to-assume: ${{ env.CLOUDFORMATION_ROLE_ARN }}
-        role-duration-seconds: 1200
-        role-skip-session-tagging: true
+    - name: Assume cloudformation role
+      shell: bash
+      run: |
+        aws sts assume-role \
+          --role-arn ${{ env.CLOUDFORMATION_ROLE_ARN }} \
+          --role-session-name github-actions-cloudformation \
+          --query 'Credentials' \
+          --output json > /tmp/credentials
+        echo "AWS_ACCESS_KEY_ID=$(jq -r .AccessKeyId /tmp/credentials)" >> $GITHUB_ENV
+        echo "AWS_SECRET_ACCESS_KEY=$(jq -r .SecretAccessKey /tmp/credentials)" >> $GITHUB_ENV
+        echo "AWS_SESSION_TOKEN=$(jq -r .SessionToken /tmp/credentials)" >> $GITHUB_ENV
 
     - name: Deploy to cloudformation
       shell: bash

--- a/deploy-to-cloudformation-cli/action.yml
+++ b/deploy-to-cloudformation-cli/action.yml
@@ -40,7 +40,6 @@ runs:
       run: |
         echo "AWS_DEFAULT_REGION=${{ inputs.region }}" >> $GITHUB_ENV
         echo "AWS_REGION=${{ inputs.region }}" >> $GITHUB_ENV
-        echo "AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)" >> $GITHUB_ENV
 
     - name: Get ECR Image
       shell: bash

--- a/deploy-to-cloudformation-cli/action.yml
+++ b/deploy-to-cloudformation-cli/action.yml
@@ -36,14 +36,23 @@ runs:
         branch: ${{ github.head_ref || github.ref_name }}
       
     - name: Configure AWS credentials
-      # Log in without assuming role first, to get ECR registry name
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-region: ${{ inputs.region }}
+      shell: bash
+      run: |
+        echo "AWS_DEFAULT_REGION=${{ inputs.region }}" >> $GITHUB_ENV
+        echo "AWS_REGION=${{ inputs.region }}" >> $GITHUB_ENV
+        echo "AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)" >> $GITHUB_ENV
 
-    - name: Login to Amazon ECR
-      id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+    - name: Get ECR Image
+      shell: bash
+      id: get-ecr-image
+      run: |
+        echo "registry-id=$(
+          aws ecr describe-images \
+            --repository-name ${{ github.event.repository.name }} \
+            --image-ids imageTag='${{ inputs.ldt-environment }}-${{ inputs.github-sha }}' \
+            --query 'imageDetails[0].registryId' \
+            --output text
+        )" >> $GITHUB_OUTPUT
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -63,7 +72,7 @@ runs:
           --capabilities CAPABILITY_NAMED_IAM \
           --parameter-overrides \
             $(cat configs/${{ inputs.ldt-environment }}.json | jq -r '.Parameters | to_entries[] | "\(.key)=\(.value)"') \
-            ECRImage=${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ inputs.ldt-environment }}-${{ inputs.github-sha }} \
+            ECRImage=${{ steps.get-ecr-image.outputs.registry-id }}.dkr.ecr.${{ inputs.region }}.amazonaws.com/${{ github.event.repository.name }}:${{ inputs.ldt-environment }}-${{ inputs.github-sha }} \
             CommitHash=${{ inputs.github-sha }} \
             ${{ inputs.extra-flags }}
 


### PR DESCRIPTION
Navigates the *absolute minefield* that is AWS CLI. Calls `ecr` to get the repository id, and `sts` to assume the deployment role, meaning we no longer have a dependency on the deprecated AWS actions. Also runs very, very slightly faster.

This is necessary for https://github.com/stampedeapp/web/pull/10554 because AWS's actions read from ENV in a weird and unsafe way.

Tested [here](https://github.com/stampedeapp/graphql-service/actions/runs/3377955231/jobs/5608857745) - testing web [here](https://github.com/stampedeapp/web/actions/runs/3378581122).

The API is the same - it'll just work with ENV being passed straight in rather than ephemerally being in top-level-env.