### PR TITLE
Remove reuse-image logic and clean up e2e testing logic

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -7,7 +7,7 @@ on:
         type: string
         description: Name of the stack to deploy to
         required: true
-      run-e2e-tests:
+      skip-e2e-tests:
         type: string
         description: Run e2e tests before deploying
         required: false
@@ -94,7 +94,7 @@ jobs:
     steps:
       - uses: stampedeapp/actions/setup@main
       - uses: stampedeapp/actions/run-cypress@main
-        if: ${{ inputs.run-e2e-tests == 'true' }}
+        if: ${{ inputs.skip-e2e-tests != 'true' }}
         with: 
           e2e-testing-key: ${{ secrets.E2E_TESTING_KEY }}
         env:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -87,7 +87,6 @@ jobs:
     runs-on: ubuntu-latest
     container: cypress/browsers:node16.17.0-chrome106
     needs: deploy-staging
-    if: ${{ inputs.run-e2e-tests == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -95,6 +94,7 @@ jobs:
     steps:
       - uses: stampedeapp/actions/setup@main
       - uses: stampedeapp/actions/run-cypress@main
+        if: ${{ inputs.run-e2e-tests == 'true' }}
         with: 
           e2e-testing-key: ${{ secrets.E2E_TESTING_KEY }}
         env:
@@ -110,7 +110,6 @@ jobs:
       - build-production
       - deploy-staging
       - e2e-testing
-    if: ${{ always() && (inputs.run-e2e-tests == 'false' || needs.e2e-testing.result == 'success') && (needs.build-production.result == 'success') && (needs.deploy-staging.result == 'success') }}
     concurrency:
       group: cloudformation-production
     steps:

--- a/.github/workflows/emergency-deploy.yml
+++ b/.github/workflows/emergency-deploy.yml
@@ -16,11 +16,6 @@ on:
         type: string
         description: Name of the stack to deploy to
         required: true
-      reuse-image:
-        type: string
-        description: 'Reuse existing image if it exists?'
-        required: false
-        default: 'false'
       sha:
         type: string
         description: SHA of the commit to use for deployment
@@ -61,7 +56,6 @@ jobs:
           npm-token: ${{ secrets.NPM_READONLY_TOKEN }}
           docker-hub-username: ${{ secrets.DOCKER_USERNAME }}
           docker-hub-password: ${{ secrets.DOCKER_PASSWORD }}
-          reuse-image: ${{ inputs.reuse-image }}
           github-sha: ${{ inputs.sha }}
   
   execute-changeset:

--- a/deploy-to-ecr/action.yml
+++ b/deploy-to-ecr/action.yml
@@ -27,10 +27,6 @@ inputs:
     description: The SHA of the commit to use for deployment.
     required: false
     default: ${{ github.sha }}
-  reuse-image:
-    description: Whether to reuse an existing image if it exists.
-    required: false
-    default: 'false'
     
 runs:
   using: composite
@@ -52,14 +48,7 @@ runs:
         username: ${{ inputs.docker-hub-username }}
         password: ${{ inputs.docker-hub-password }}
 
-    - name: Exit if image already exists
-      id: check-image-exists
-      continue-on-error: true
-      run: ${{ inputs.reuse-image == 'false' }} || aws ecr describe-images --repository-name ${{ inputs.image-name }} --image-ids imageTag=${{ inputs.ldt-environment }}-${{ inputs.github-sha }}
-      shell: bash
-
     - name: Set up Docker Buildx
-      if: ${{ always() && (inputs.reuse-image == 'false' || steps.check-image-exists.outcome == 'failure') }}
       id: buildx
       uses: docker/setup-buildx-action@master
       with:

--- a/workflow-templates/_templates/workflow/emergency/emergency_deploy.yml
+++ b/workflow-templates/_templates/workflow/emergency/emergency_deploy.yml
@@ -7,11 +7,6 @@ name: Emergency Deployment (<%= name %>)
 on:
   workflow_dispatch:
     inputs:
-      reuse-image:
-        description: 'Try to reuse previously built image?'
-        required: false
-        default: false
-        type: boolean
       sha:
         description: 'SHA to deploy'
         required: false
@@ -24,5 +19,4 @@ jobs:
     secrets: inherit
     with:
       stack-name: <%= stack %>
-      reuse-image: ${{ github.event.inputs.reuse-image == 'true' }}
       sha: ${{ github.event.inputs.sha }}


### PR DESCRIPTION
1. Remove reuse-image logic as it was causing complicated logic failures 
2. Tidy up e2e testing step to always run and skip if we don't want to run