### PR TITLE
Bump up test runner spec

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -7,7 +7,7 @@ on:
         type: string
         description: Command to run to setup the test environment
         required: false
-        default: ''
+        default: ""
 
 env:
   NODE_AUTH_TOKEN: ${{ secrets.NPM_READONLY_TOKEN }}
@@ -25,7 +25,7 @@ jobs:
       - uses: stampedeapp/actions/setup@main
       - run: yarn lint
   jest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-core
     steps:
       - uses: stampedeapp/actions/setup@main
       - run: ${{ inputs.test-setup-command }}


### PR DESCRIPTION
Updates the `jest` job in the `static` action to use the `ubuntu-16-core` runner for more memory.
This is a temporary workaround to unblock booking service tests, as they run out of memory on the current runner.

