### PR TITLE
Actions/feat/type coverage

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Get type coverage
         run: |
           export coverage=$(type-coverage | head -n 1 | grep -oE "[^ ]+$")
-          echo "coverage=$coverage" >> $GITHUB_ENV
+          echo "coverage=${coverage%?}" >> $GITHUB_ENV
           echo "Coverage: $coverage" >> $GITHUB_OUTPUT
       - name: Upload to datadog
         uses: masci/datadog@v1

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: stampedeapp/actions/setup@main
-      - run: yarn global install type-coverage typescript
+      - run: yarn global add type-coverage typescript
       - name: Get type coverage
         run: |
           export coverage=$(type-coverage | head -n 1 | grep -oE "[^ ]+$")

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,3 +34,27 @@ jobs:
         if: ${{ inputs.test-setup-command != '' }}
       - uses: stampedeapp/actions/jest@main
       - uses: stampedeapp/actions/jest-coverage@main
+  type-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: stampedeapp/actions/setup@main
+      - run: yarn global install type-coverage typescript
+      - name: Get type coverage
+        run: |
+          export coverage=$(type-coverage | head -n 1 | grep -oE "[^ ]+$")
+          echo "coverage=$coverage" >> $GITHUB_ENV
+          echo "Coverage: $coverage" >> $GITHUB_OUTPUT
+      - name: Upload to datadog
+        uses: masci/datadog@v1
+        with: 
+          api-key: ${{ secrets.DATADOG_API_KEY }}
+          metrics: |
+            - type: gauge
+              name: type-coverage
+              value: ${{ env.coverage }}
+              tags:
+                - "repo:${{ github.repository }}"
+                - "service:${{ github.event.repository.name }}"
+                - "branch:${{ github.ref }}"
+                - "commit:${{ github.sha }}"
+

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -50,7 +50,7 @@ jobs:
           api-key: ${{ secrets.DATADOG_API_KEY }}
           metrics: |
             - type: gauge
-              name: type-coverage
+              name: github.type_coverage
               value: ${{ env.coverage }}
               tags:
                 - "repo:${{ github.repository }}"

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           export coverage=$(type-coverage | head -n 1 | grep -oE "[^ ]+$")
           echo "coverage=${coverage%?}" >> $GITHUB_ENV
-          echo "Coverage: $coverage" >> $GITHUB_OUTPUT
+          echo "Coverage: $coverage" >> $GITHUB_STEP_SUMMARY
       - name: Upload to datadog
         uses: masci/datadog@v1
         with: 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -50,11 +50,10 @@ jobs:
           api-key: ${{ secrets.DATADOG_API_KEY }}
           metrics: |
             - type: gauge
-              name: github.type_coverage
+              name: code.typescript_coverage
               value: ${{ env.coverage }}
               tags:
                 - "repo:${{ github.repository }}"
                 - "service:${{ github.event.repository.name }}"
                 - "branch:${{ github.ref }}"
-                - "commit:${{ github.sha }}"
 


### PR DESCRIPTION
This works. Adds type coverage to job summary, and also sends it to datadog. Just blanket sending them all since you can filter in dd by branch name.

This uses global add for type-coverage (CORRECT) and typescript (INCORRECT) - which means its technically using newest typescript and can explode if they breaking-change it. Otherwise we're good.

![image](https://user-images.githubusercontent.com/77631610/210627491-cb3c323d-ec44-48af-9be3-56b892ef99d7.png)
