### PR TITLE
Upload coverage to codacy and codeclimate

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,7 +36,6 @@ jobs:
       - uses: stampedeapp/actions/jest@main
         with:
           workers: 2
-      - uses: stampedeapp/actions/jest-coverage@main
   type-coverage:
     runs-on: ubuntu-latest
     steps:

--- a/jest/action.yml
+++ b/jest/action.yml
@@ -21,15 +21,25 @@ runs:
     - name: Run Jest
       shell: bash
       run: yarn jest --maxWorkers=${{ inputs.workers }} --shard=${{ inputs.shard-number }}/${{ inputs.shard-total }} --ci --coverage --testLocationInResults --forceExit
-      env:
-        NODE_ENV: test
-    - run: rm -rf coverage/lcov-report
-      shell: bash
-    - run: mv coverage/lcov.info coverage/coverage-${{ inputs.shard-number }}.lcov
-      shell: bash
-    - run: mv coverage/coverage-final.json coverage/coverage-final-${{ inputs.shard-number }}.json
-      shell: bash
-    - uses: actions/upload-artifact@v3
+    - uses: stampedeapp/codeclimate-action@main
+      if: always()
       with:
-        name: coverage-artifacts
-        path: coverage/
+        debug: true 
+        coverageCommand: echo 'Uploading to Code Coverage'
+      env:
+        CC_TEST_REPORTER_ID: ${{ inputs.code-climate-key == '' && env.CC_TEST_REPORTER_ID || inputs.code-climate-key }}
+    - name: Run codacy-coverage-reporter
+      if: always()
+      uses: codacy/codacy-coverage-reporter-action@v1
+      with:
+        api-token: ${{ secrets.CODACY_API_TOKEN }}
+        # or
+        # api-token: ${{ secrets.CODACY_API_TOKEN }}
+        coverage-reports: coverage/lcov.info
+        # or a comma-separated list for multiple reports
+        # coverage-reports: <PATH_TO_REPORT>, <PATH_TO_REPORT>
+    - uses: actions/upload-artifact@v3.1.1
+      if: always()
+      with:
+        name: coverage
+        path: coverage


### PR DESCRIPTION
Restructure jest workflows so that we always upload the coverage files to both code climate & codacy for review. 