### PR TITLE
Run cypress during Staging deploy section as a matrix workflow call

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,24 @@
+name: Cypress
+
+on:
+  workflow_call:
+
+jobs:
+  e2e-testing:
+    runs-on: ubuntu-latest
+    container: cypress/browsers:node16.17.0-chrome106
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+    steps:
+      - uses: stampedeapp/actions/setup@main
+      - uses: stampedeapp/actions/run-cypress@main
+        timeout-minutes: 30
+        with: 
+          e2e-testing-key: ${{ secrets.E2E_TESTING_KEY }}
+        env:
+          ENV: staging
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_DEPLOYSENTINEL_KEY: ${{ secrets.CYPRESS_DEPLOYSENTINEL_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -83,26 +83,8 @@ jobs:
           stack-name: ${{ inputs.stack-name }}
           ldt-environment: staging
 
-  e2e-testing:
-    runs-on: ubuntu-latest
-    container: cypress/browsers:node16.17.0-chrome106
-    needs: deploy-staging
-    if: ${{ inputs.run-e2e-tests == 'true' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
-    steps:
-      - uses: stampedeapp/actions/setup@main
-      - uses: stampedeapp/actions/run-cypress@main
-        timeout-minutes: 30
-        with: 
-          e2e-testing-key: ${{ secrets.E2E_TESTING_KEY }}
-        env:
-          ENV: staging
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          CYPRESS_DEPLOYSENTINEL_KEY: ${{ secrets.CYPRESS_DEPLOYSENTINEL_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: stampedeapp/actions/.github/workflows/cypress.yml@main
+        if: ${{ inputs.run-e2e-tests == 'true' }}
 
   deploy-production:
     runs-on: ubuntu-latest
@@ -110,8 +92,6 @@ jobs:
     needs:
       - build-production
       - deploy-staging
-      - e2e-testing
-    if: ${{ always() && (inputs.run-e2e-tests == 'false' || needs.e2e-testing.result == 'success') && (needs.build-production.result == 'success') && (needs.deploy-staging.result == 'success') }}
     concurrency:
       group: cloudformation-production
     steps:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -68,24 +68,6 @@ jobs:
         with:
           stack-name: ${{ inputs.stack-name }}
           ldt-environment: staging
-
-  e2e-testing:
-    runs-on: ubuntu-latest
-    container: cypress/browsers:node16.17.0-chrome106
-    needs: deploy-staging
-    if: ${{ inputs.run-e2e-tests == 'true' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
-    steps:
-      - uses: stampedeapp/actions/setup@main
-      - uses: stampedeapp/actions/run-cypress@main
-        timeout-minutes: 30
-        with: 
-          e2e-testing-key: ${{ secrets.E2E_TESTING_KEY }}
-        env:
-          ENV: staging
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          CYPRESS_DEPLOYSENTINEL_KEY: ${{ secrets.CYPRESS_DEPLOYSENTINEL_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - uses: stampedeapp/actions/.github/workflows/cypress.yml@main
+        if: ${{ inputs.run-e2e-tests == 'true' }}


### PR DESCRIPTION
Move the E2E testing step into the staging deployment step so that failures in E2E testing show up as part of the Github Deployments flow.