### PR TITLE
Make deploy.yml deploy only to dev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,15 +3,6 @@ name: Deploy
 on:
   workflow_call:
     inputs:
-      ldt-environment:
-        type: string
-        description: LDT environment to use
-        required: false
-        default: dev
-      environment:
-        type: string
-        required: false
-        default: Development
       stack-name:
         type: string
         description: Name of the stack to deploy to
@@ -52,7 +43,7 @@ jobs:
       - uses: stampedeapp/actions/setup@main
       - uses: stampedeapp/actions/deploy-to-ecr@main
         with:
-          ldt-environment: ${{ inputs.ldt-environment }}
+          ldt-environment: dev
           npm-token: ${{ secrets.NPM_READONLY_TOKEN }}
           docker-hub-username: ${{ secrets.DOCKER_USERNAME }}
           docker-hub-password: ${{ secrets.DOCKER_PASSWORD }}
@@ -60,16 +51,13 @@ jobs:
   
   execute-changeset:
     runs-on: ubuntu-latest-4-cores
-    environment: ${{ inputs.environment }}
+    environment: Development
     needs:
       - static
       - build
     concurrency:
-      group: cloudformation-${{ inputs.ldt-environment }}
+      group: cloudformation-dev
     steps:
-      - uses: stampedeapp/actions/check-code-freeze@main
-        with:
-          github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
       - uses: stampedeapp/actions/setup@main
       - run: yarn predeploy || true
         env:
@@ -77,6 +65,6 @@ jobs:
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:
           stack-name: ${{ inputs.stack-name }}
-          ldt-environment: ${{ inputs.ldt-environment }}
+          ldt-environment: dev
           github-sha: ${{ inputs.sha }}
 


### PR DESCRIPTION
Since we have environment specific workflows, it makes sense to remove the level of abstraction around environment. This PR also removes the change freeze check which is required for deploying to staging and production, hence the restriction that this workflow can only deploy to dev. 