### PR TITLE
feat: chill out a bit on code freezes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,13 @@ on:
         description: Command to run to setup the test environment
         required: false
         default: ''
+      enforce-change-freeze:
+        type: string
+        description: Whether to enforce a change freeze if currently frozen
+        required: false
+        default: 'false'
+
+
 env:
   NODE_AUTH_TOKEN: ${{ secrets.NPM_READONLY_TOKEN }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -62,6 +69,10 @@ jobs:
       - run: yarn predeploy || true
         env:
           MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
+      - uses: stampedeapp/actions/check-code-freeze@main
+        with:
+          github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
+        if: ${{ inputs.enforce-change-freeze == 'true' }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:
           stack-name: ${{ inputs.stack-name }}


### PR DESCRIPTION
`deploy` is currently only used for dev branches - this switches the default for `deploy` to *not* enforce change freezes, as we don't worry about dev (but still leaves it configurable if necessary)