### PR TITLE
feat: fail properly if predeploy fails

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -75,15 +75,9 @@ jobs:
     concurrency:
       group: cloudformation-staging
     steps:
-      - uses: stampedeapp/actions/check-code-freeze@main
-        with:
-          github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
-      - uses: stampedeapp/actions/setup@main
-      - run: LDT_ENV=staging if [ "$(cat package.json | jq -r .scripts.predeploy)" != "null" ]; then yarn predeploy; fi;
-        env:
-          MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:
+          github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
           stack-name: ${{ inputs.stack-name }}
           ldt-environment: staging
 
@@ -119,14 +113,8 @@ jobs:
     concurrency:
       group: cloudformation-production
     steps:
-      - uses: stampedeapp/actions/check-code-freeze@main
-        with:
-          github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
-      - uses: stampedeapp/actions/setup@main
-      - run: LDT_ENV=production if [ "$(cat package.json | jq -r .scripts.predeploy)" != "null" ]; then yarn predeploy; fi;
-        env:
-          MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:
+          github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
           stack-name: ${{ inputs.stack-name }}
           ldt-environment: prod

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
       - uses: stampedeapp/actions/setup@main
-      - run: LDT_ENV=staging yarn predeploy || true
+      - run: LDT_ENV=staging if [ "$(cat package.json | jq -r .scripts.predeploy)" != "null" ]; then yarn predeploy; fi;
         env:
           MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
@@ -123,7 +123,7 @@ jobs:
         with:
           github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
       - uses: stampedeapp/actions/setup@main
-      - run: LDT_ENV=production yarn predeploy || true
+      - run: LDT_ENV=production if [ "$(cat package.json | jq -r .scripts.predeploy)" != "null" ]; then yarn predeploy; fi;
         env:
           MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -77,9 +77,9 @@ jobs:
     steps:
       - uses: stampedeapp/actions/predeploy@main
         with: 
-          ldt-environment: staging
           github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
         env:
+          LDT_ENVIRONMENT: staging
           MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:
@@ -121,9 +121,9 @@ jobs:
     steps:
       - uses: stampedeapp/actions/predeploy@main
         with: 
-          ldt-environment: production
           github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
         env:
+          LDT_ENVIRONMENT: production
           MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -79,7 +79,7 @@ jobs:
         with: 
           github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
         env:
-          LDT_ENVIRONMENT: staging
+          LDT_ENV: staging
           MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -75,6 +75,12 @@ jobs:
     concurrency:
       group: cloudformation-staging
     steps:
+      - uses: stampedeapp/actions/predeploy@main
+        with: 
+          ldt-environment: staging
+          github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
+        env:
+          MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:
           github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
@@ -113,6 +119,12 @@ jobs:
     concurrency:
       group: cloudformation-production
     steps:
+      - uses: stampedeapp/actions/predeploy@main
+        with: 
+          ldt-environment: production
+          github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
+        env:
+          MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:
           github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -63,16 +63,14 @@ jobs:
     steps:
       - uses: stampedeapp/actions/predeploy@main
         with: 
-          ldt-environment: staging
           github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
         env:
+          LDT_ENVIRONMENT: staging
           MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:
           stack-name: ${{ inputs.stack-name }}
           ldt-environment: staging
-        env:
-          MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
 
   e2e-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -61,11 +61,18 @@ jobs:
     concurrency:
       group: cloudformation-staging
     steps:
+      - uses: stampedeapp/actions/predeploy@main
+        with: 
+          ldt-environment: staging
+          github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
+        env:
+          MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:
-          github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
           stack-name: ${{ inputs.stack-name }}
           ldt-environment: staging
+        env:
+          MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
 
   e2e-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -61,15 +61,9 @@ jobs:
     concurrency:
       group: cloudformation-staging
     steps:
-      - uses: stampedeapp/actions/check-code-freeze@main
-        with:
-          github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
-      - uses: stampedeapp/actions/setup@main
-      - run: LDT_ENV=staging if [ "$(cat package.json | jq -r .scripts.predeploy)" != "null" ]; then yarn predeploy; fi;
-        env:
-          MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:
+          github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
           stack-name: ${{ inputs.stack-name }}
           ldt-environment: staging
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           github-token: ${{ secrets.WORKFLOW_CALL_TOKEN }}
       - uses: stampedeapp/actions/setup@main
-      - run: LDT_ENV=staging yarn predeploy || true
+      - run: LDT_ENV=staging if [ "$(cat package.json | jq -r .scripts.predeploy)" != "null" ]; then yarn predeploy; fi;
         env:
           MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,10 +58,6 @@ jobs:
     concurrency:
       group: cloudformation-dev
     steps:
-      - uses: stampedeapp/actions/setup@main
-      - run: LDT_ENV=dev if [ "$(cat package.json | jq -r .scripts.predeploy)" != "null" ]; then yarn predeploy; fi;
-        env:
-          MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:
           stack-name: ${{ inputs.stack-name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
     concurrency:
       group: cloudformation-dev
     steps:
-      - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
+      - uses: stampedeapp/actions/deploy-to-cloudformation-cli@wip
         with:
           stack-name: ${{ inputs.stack-name }}
           ldt-environment: dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,12 @@ jobs:
     concurrency:
       group: cloudformation-dev
     steps:
-      - uses: stampedeapp/actions/deploy-to-cloudformation-cli@wip
+      - uses: stampedeapp/actions/predeploy@main
+        with: 
+          ldt-environment: dev
+        env:
+          MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
+      - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:
           stack-name: ${{ inputs.stack-name }}
           ldt-environment: dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,10 +58,9 @@ jobs:
     concurrency:
       group: cloudformation-dev
     steps:
-      - uses: stampedeapp/actions/predeploy@wip
-        with: 
-          ldt-environment: dev
+      - uses: stampedeapp/actions/predeploy@main
         env:
+          LDT_ENVIRONMENT: dev
           MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,9 +58,9 @@ jobs:
     concurrency:
       group: cloudformation-dev
     steps:
-      - uses: stampedeapp/actions/predeploy@main
+      - uses: stampedeapp/actions/predeploy@wip
         env:
-          LDT_ENVIRONMENT: dev
+          LDT_ENV: dev
           MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
     concurrency:
       group: cloudformation-dev
     steps:
-      - uses: stampedeapp/actions/predeploy@wip
+      - uses: stampedeapp/actions/predeploy@main
         env:
           LDT_ENVIRONMENT: dev
           MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
       group: cloudformation-dev
     steps:
       - uses: stampedeapp/actions/setup@main
-      - run: LDT_ENV=dev yarn predeploy || true
+      - run: LDT_ENV=dev if [ "$(cat package.json | jq -r .scripts.predeploy)" != "null" ]; then yarn predeploy; fi;
         env:
           MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
       - uses: stampedeapp/actions/deploy-to-cloudformation-cli@main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
     concurrency:
       group: cloudformation-dev
     steps:
-      - uses: stampedeapp/actions/predeploy@wip
+      - uses: stampedeapp/actions/predeploy@main
         env:
           LDT_ENV: dev
           MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
     concurrency:
       group: cloudformation-dev
     steps:
-      - uses: stampedeapp/actions/predeploy@main
+      - uses: stampedeapp/actions/predeploy@wip
         with: 
           ldt-environment: dev
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
     concurrency:
       group: cloudformation-dev
     steps:
-      - uses: stampedeapp/actions/predeploy@main
+      - uses: stampedeapp/actions/predeploy@wip
         env:
           LDT_ENVIRONMENT: dev
           MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}

--- a/deploy-to-cloudformation-cli/action.yml
+++ b/deploy-to-cloudformation-cli/action.yml
@@ -20,12 +20,7 @@ inputs:
     required: false
     description: The AWS region to use for deployment.
     default: eu-west-1
-  github-token:
-    description: |
-      Token with which to check the code freeze status.
-      If not provided, will skip the code freeze check
-    required: false
-    default: ''
+
 
 outputs:
   stack-id:
@@ -35,10 +30,11 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: stampedeapp/actions/predeploy@main
+    - name: Checkout files
+      uses: Bhacaz/checkout-files@v2
       with:
-        ldt-environment: dev
-        github-token: ${{ inputs.github-token }}
+        files: cloudformation/cloudformation.yaml configs/${{ inputs.ldt-environment }}.json
+        branch: ${{ inputs.github-sha }}
 
     - name: Validate Cloudformation Files
       uses: stampedeapp/actions/cloudformation-validate@main

--- a/deploy-to-cloudformation-cli/action.yml
+++ b/deploy-to-cloudformation-cli/action.yml
@@ -20,6 +20,12 @@ inputs:
     required: false
     description: The AWS region to use for deployment.
     default: eu-west-1
+  github-token:
+    description: |
+      Token with which to check the code freeze status.
+      If not provided, will skip the code freeze check
+    required: false
+    default: ''
 
 outputs:
   stack-id:
@@ -29,11 +35,10 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Checkout files
-      uses: Bhacaz/checkout-files@v2
+    - uses: stampedeapp/actions/predeploy@main
       with:
-        files: cloudformation/cloudformation.yaml configs/${{ inputs.ldt-environment }}.json
-        branch: ${{ inputs.github-sha }}
+        ldt-environment: dev
+        github-token: ${{ inputs.github-token }}
 
     - name: Validate Cloudformation Files
       uses: stampedeapp/actions/cloudformation-validate@main

--- a/predeploy/action.yml
+++ b/predeploy/action.yml
@@ -22,6 +22,6 @@ runs:
       shell: bash
       run: echo "script=$(cat package.json | jq -r .scripts.predeploy)" >> $GITHUB_OUTPUT
     - shell: bash
-      if: ${{ steps.predeploy.outputs.script }}
+      if: ${{ steps.predeploy.outputs.script != 'null' }}
       name: Run predeploy script
       run: yarn predeploy

--- a/predeploy/action.yml
+++ b/predeploy/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - uses: stampedeapp/actions/check-code-freeze@main
-      if: ${{ inputs.github-token !== '' }}
+      if: ${{ inputs.github-token != '' }}
       with:
         github-token: ${{ inputs.github-token }}
     - uses: stampedeapp/actions/setup@main

--- a/predeploy/action.yml
+++ b/predeploy/action.yml
@@ -8,9 +8,6 @@ inputs:
       If not provided, will skip the code freeze check
     required: false
     default: ''
-  ldt-environment:
-    description: The environment to set LDT_ENV to.
-    required: true
 
 runs:
   using: composite
@@ -28,5 +25,3 @@ runs:
       if: ${{ steps.predeploy.outputs.script }}
       name: Run predeploy script
       run: yarn predeploy
-      env:
-        LDT_ENV: ${{ inputs.ldt-environment }}

--- a/predeploy/action.yml
+++ b/predeploy/action.yml
@@ -1,0 +1,32 @@
+name: Execute predeploy steps
+description: Execute predeploy steps
+
+inputs:
+  github-token:
+    description: |
+      Token with which to check the code freeze status.
+      If not provided, will skip the code freeze check
+    required: false
+    default: ''
+  ldt-environment:
+    description: The environment to set LDT_ENV to.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: stampedeapp/actions/check-code-freeze@main
+      if: ${{ inputs.github-token !== '' }}
+      with:
+        github-token: ${{ inputs.github-token }}
+    - uses: stampedeapp/actions/setup@main
+    - id: predeploy
+      name: Check for predeploy script
+      shell: bash
+      run: echo "script=$(cat package.json | jq -r .scripts.predeploy)" >> $GITHUB_OUTPUT
+    - shell: bash
+      if: ${{ steps.predeploy.outputs.script }}
+      name: Run predeploy script
+      run: yarn predeploy
+      env:
+        LDT_ENV: ${{ inputs.ldt-environment }}


### PR DESCRIPTION
This jq is your fault @LukeSheard. It's entirely your fault.

(use an `if` statement to conditionally call predeploy rather than just eating errors. npm supports `--if-present` but yarn doesn't, so we have to do this crap)