### PR TITLE
Do install in static workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -26,14 +26,8 @@ env:
   CLOUDFORMATION_ROLE_ARN: ${{ secrets.CLOUDFORMATION_ROLE_ARN }}
 
 jobs:
-  install:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: stampedeapp/actions/install-dependencies@main
-
   static:
     uses: stampedeapp/actions/.github/workflows/static.yml@main
-    needs: install
     secrets: inherit
     with:
       test-setup-command: ${{ inputs.test-setup-command }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -26,14 +26,8 @@ env:
   CLOUDFORMATION_ROLE_ARN: ${{ secrets.CLOUDFORMATION_ROLE_ARN }}
 
 jobs:
-  install:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: stampedeapp/actions/install-dependencies@main
-
   static:
     uses: stampedeapp/actions/.github/workflows/static.yml@main
-    needs: install
     secrets: inherit
     with:
       test-setup-command: ${{ inputs.test-setup-command }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,14 +19,8 @@ env:
   CLOUDFORMATION_ROLE_ARN: ${{ secrets.CLOUDFORMATION_ROLE_ARN }}
 
 jobs:
-  install:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: stampedeapp/actions/install-dependencies@main
-
   static:
     uses: stampedeapp/actions/.github/workflows/static.yml@main
-    needs: install
     secrets: inherit
     with:
       test-setup-command: ${{ inputs.test-setup-command }}

--- a/.github/workflows/merge-queue-production.yml
+++ b/.github/workflows/merge-queue-production.yml
@@ -26,14 +26,8 @@ env:
   CLOUDFORMATION_ROLE_ARN: ${{ secrets.CLOUDFORMATION_ROLE_ARN }}
 
 jobs:
-  install:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: stampedeapp/actions/install-dependencies@main
-
   static:
     uses: stampedeapp/actions/.github/workflows/static.yml@main
-    needs: install
     secrets: inherit
     with:
       test-setup-command: ${{ inputs.test-setup-command }}

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -21,14 +21,8 @@ env:
   CLOUDFORMATION_ROLE_ARN: ${{ secrets.CLOUDFORMATION_ROLE_ARN }}
 
 jobs:
-  install:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: stampedeapp/actions/install-dependencies@main
-
   static:
     uses: stampedeapp/actions/.github/workflows/static.yml@main
-    needs: install
     secrets: inherit
     with:
       test-setup-command: ${{ inputs.test-setup-command }}

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -15,15 +15,22 @@ env:
   CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_KEY }}
 
 jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: stampedeapp/actions/install-dependencies@main
+      
   typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: install
     steps:
       - uses: stampedeapp/actions/setup@main
       - run: yarn tsc
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: install
     steps:
       - uses: stampedeapp/actions/setup@main
       - run: yarn lint
@@ -61,6 +68,7 @@ jobs:
   jest:
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 30
+    needs: install
     steps:
       - uses: stampedeapp/actions/setup@main
         with:


### PR DESCRIPTION
Move `install-dependencies` into `static.yml` workflow to simplify shared workflows.