### PR TITLE
fix: migrate emergency deploy to use new action

### DIFF
--- a/.github/workflows/emergency-deploy.yml
+++ b/.github/workflows/emergency-deploy.yml
@@ -3,24 +3,20 @@ name: Deploy
 on:
   workflow_call:
     inputs:
-      ldt-environment:
-        type: string
-        description: LDT environment to use
-        required: false
-        default: prod
-      environment:
-        type: string
-        required: false
-        default: Production
       stack-name:
         type: string
         description: Name of the stack to deploy to
         required: true
       sha:
         type: string
-        description: SHA of the commit to use for deployment
+        description: DEPRECATED - do not use, as it will be ignored.
         required: false
         default: ${{ github.sha }}
+      reuse-image:
+        type: string
+        description: DEPRECATED - do not use, as it will be ignored.
+        required: false
+        default: "false"
 
 env:
   NODE_AUTH_TOKEN: ${{ secrets.NPM_READONLY_TOKEN }}
@@ -44,20 +40,11 @@ jobs:
               }
           PAYLOAD
 
-  execute-changeset:
-    runs-on: ubuntu-latest-16-cores
-    environment: ${{ inputs.environment }}
-    concurrency:
-      group: ${{ github.workflow }}-${{inputs.environment}}-${{ inputs.stack-name }}
-    steps:
-      - uses: stampedeapp/actions/deploy@main
-        with:
-          stack-name: ${{ inputs.stack-name }}
-          ldt-environment: ${{ inputs.ldt-environment }}
-          npm-token: ${{ secrets.NPM_READONLY_TOKEN }}
-          docker-hub-username: ${{ secrets.DOCKER_USERNAME }}
-          docker-hub-password: ${{ secrets.DOCKER_PASSWORD }}
-          github-sha: ${{ inputs.sha }}
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_DEPLOY_TOKEN }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          s3-path: ${{ secrets.S3_PATH }}
+  deploy-production:
+    uses: stampedeapp/actions/.github/workflows/aws-ecs-deploy.yml@main
+    with:
+      ldt-env: "production"
+      ldt-environment: "prod"
+      stack-name: ${{ inputs.stack-name }}
+      environment: "Production"
+    secrets: inherit


### PR DESCRIPTION
Emergency deploy was never updated to use `aws-ecs-deploy` when the actions were moved across. This does that.

I've left the old parameters on there, but they're deprecated. There's no reason to explicitly specify `sha` as you can just point at a branch, and the `reuse-image` behaviour isn't worth maintaining with deploy times as low as they are.