### PR TITLE
Report merge commit to deploy times in datadog

### DIFF
--- a/.github/workflows/aws-ecs-deploy-and-test.yml
+++ b/.github/workflows/aws-ecs-deploy-and-test.yml
@@ -124,3 +124,30 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           CYPRESS_DEPLOYSENTINEL_KEY: ${{ secrets.CYPRESS_DEPLOYSENTINEL_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  report-deploy-time:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - uses: stampedeapp/actions/setup@main
+
+      - name: Calculate deploy time
+        shell: bash
+        run: |
+          GIT_COMMIT_TIME_SECONDS=$(git show -s --format=%ct)
+          CURRENT_TIME_SECONDS=$(date +%s)
+          echo "DEPLOYMENT_TIME_SECONDS=$(($CURRENT_TIME_SECONDS - $GIT_COMMIT_TIME_SECONDS))" >> $GITHUB_ENV
+
+      - name: Report deploy time
+        uses: masci/datadog@v1
+        with:
+          api-key: ${{ secrets.DATADOG_API_KEY }}
+          metrics: |
+            - type: gauge
+              name: ci.merge_commit_to_deploy_time
+              value: ${{ env.DEPLOYMENT_TIME_SECONDS }}
+              tags:
+                - "repo:${{ github.repository }}"
+                - "service:${{ github.event.repository.name }}"
+                - "branch:${{ github.ref }}"
+                - "environment:${{ inputs.environment }}"


### PR DESCRIPTION
This reports a new stat, `ci.merge_commit_to_deploy_time`. It goes off the commit time of the head commit, which is the time when something is added to a GH queue.

I've kept the tags pretty much the same as other dd metrics called via these actions, but I've also included the environment.

Weird bits:
- "Commit to deploy time" with no "merge" already has meaning as CTD time, so I couldnt use it here.
- This is not the most accurate as the job gets triggered a little while after the deploy happens, but this is the least brittle way of doing this as our deploy step code gets shuffled around every 2 weeks and passing outputs could easily break.
