### PR TITLE
fix: don't deploy to staging in main pipeline

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -37,19 +37,22 @@ jobs:
     with:
       test-setup-command: ${{ inputs.test-setup-command }}
 
-  deploy-staging:
-    needs: static
-    uses: stampedeapp/actions/.github/workflows/aws-ecs-deploy.yml@main
-    with:
-      run-e2e-tests: ${{ inputs.run-e2e-tests }}
-      ldt-env: "staging"
-      ldt-environment: "staging"
-      stack-name: ${{ inputs.stack-name }}
-      environment: "Staging"
-    secrets: inherit
+  # Temporarily disabled during LME ballot code freeze.
+  # Uncomment these lines when unfreezing.
+
+  # deploy-staging:
+  #   needs: static
+  #   uses: stampedeapp/actions/.github/workflows/aws-ecs-deploy.yml@main
+  #   with:
+  #     run-e2e-tests: ${{ inputs.run-e2e-tests }}
+  #     ldt-env: "staging"
+  #     ldt-environment: "staging"
+  #     stack-name: ${{ inputs.stack-name }}
+  #     environment: "Staging"
+  #   secrets: inherit
 
   deploy-production:
-    needs: deploy-staging
+    # needs: deploy-staging
     uses: stampedeapp/actions/.github/workflows/aws-ecs-deploy.yml@main
     with:
       ldt-env: "production"


### PR DESCRIPTION
Removes the `deploy-staging` step during code freeze.

It runs e2e tests against it, which will almost always fail because most staging branches are on `frozen-main`. Better to not run at all.